### PR TITLE
DO-673 Adding aws-env to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM node:18-alpine
 
 WORKDIR /usr/src/app
 
+#Download aws-env
+RUN wget https://github.com/Droplr/aws-env/raw/master/bin/aws-env-linux-amd64 -O /bin/aws-env && chmod +x /bin/aws-env
+
 COPY . .
 RUN yarn install
 RUN yarn build
 
-CMD ["yarn", "start"]
+CMD eval $(aws-env) && yarn start


### PR DESCRIPTION
Adding [aws-env](https://github.com/Droplr/aws-env) to `Dockerfile` to retrieve env vars from AWS SSM Parameter Store.