### PR TITLE
use /bin/bash to run CMD command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY . .
 RUN yarn db:generate
 RUN yarn build
 
-CMD eval $(aws-env) && yarn start
+CMD ["/bin/bash", "-c", "eval $(aws-env) && yarn start"]


### PR DESCRIPTION
Base image was using `/bin/sh` by default, which was crashing the export of environment variables. Using `/bin/bash` instead.