### PR TITLE
VG-24 Tour in game view

### DIFF
--- a/prisma/migrations/20230105173344_settings/migration.sql
+++ b/prisma/migrations/20230105173344_settings/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Settings" (
+    "id" UUID NOT NULL,
+
+    CONSTRAINT "Settings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GameSettings" (
+    "id" UUID NOT NULL,
+    "showTutorial" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "GameSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Settings" ADD CONSTRAINT "Settings_id_fkey" FOREIGN KEY ("id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GameSettings" ADD CONSTRAINT "GameSettings_id_fkey" FOREIGN KEY ("id") REFERENCES "Settings"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,8 +23,23 @@ model User {
   games       Game[]
   SocialLogin SocialLogin[]
   scoreboards Scoreboard[]
+  settings    Settings?
 
   @@index(fields: [active])
+}
+
+model Settings {
+  id   String @id @default(uuid()) @db.Uuid
+  user User   @relation(fields: [id], references: [id], onDelete: Cascade)
+
+  gameSettings GameSettings?
+}
+
+model GameSettings {
+  id       String   @id @default(uuid()) @db.Uuid
+  settings Settings @relation(fields: [id], references: [id], onDelete: Cascade)
+
+  showTutorial Boolean @default(true)
 }
 
 enum SocialType {

--- a/schema.json
+++ b/schema.json
@@ -240,6 +240,60 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "GameSettings",
+        "description": null,
+        "fields": [
+          {
+            "name": "showTutorial",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GameSettingsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "showTutorial",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "ID",
         "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
@@ -669,6 +723,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Game",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateSettings",
+            "description": null,
+            "args": [
+              {
+                "name": "settings",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SettingsInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Settings",
                 "ofType": null
               }
             },
@@ -1126,6 +1213,68 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "Settings",
+        "description": null,
+        "fields": [
+          {
+            "name": "gameSettings",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GameSettings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SettingsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "gameSettings",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "GameSettingsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
@@ -1281,6 +1430,18 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "settings",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Settings",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/gql.ts
+++ b/src/gql.ts
@@ -51,6 +51,15 @@ export type Game = {
   startedAt: Scalars["Date"];
 };
 
+export type GameSettings = {
+  __typename?: "GameSettings";
+  showTutorial: Scalars["Boolean"];
+};
+
+export type GameSettingsInput = {
+  showTutorial: Scalars["Boolean"];
+};
+
 export type Mission = {
   __typename?: "Mission";
   bugs?: Maybe<Array<Bug>>;
@@ -77,6 +86,7 @@ export type Mutation = {
   selectBug: Game;
   startGame: Game;
   unselectBug: Game;
+  updateSettings: Settings;
 };
 
 export type MutationFinishGameArgs = {
@@ -100,6 +110,10 @@ export type MutationStartGameArgs = {
 export type MutationUnselectBugArgs = {
   bugId: Scalars["Int"];
   gameId: Scalars["ID"];
+};
+
+export type MutationUpdateSettingsArgs = {
+  settings: SettingsInput;
 };
 
 export type Query = {
@@ -160,6 +174,16 @@ export type ScoreboardPaginationInput = {
   take: Scalars["Int"];
 };
 
+export type Settings = {
+  __typename?: "Settings";
+  gameSettings?: Maybe<GameSettings>;
+  id: Scalars["ID"];
+};
+
+export type SettingsInput = {
+  gameSettings?: InputMaybe<GameSettingsInput>;
+};
+
 export type TokenResponse = {
   __typename?: "TokenResponse";
   access_token: Scalars["String"];
@@ -173,6 +197,7 @@ export type User = {
   image?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
   scoreboards?: Maybe<Array<Scoreboard>>;
+  settings?: Maybe<Settings>;
 };
 
 export type UserGamesArgs = {
@@ -296,6 +321,8 @@ export type ResolversTypes = {
   Date: ResolverTypeWrapper<Scalars["Date"]>;
   Decimal: ResolverTypeWrapper<Scalars["Decimal"]>;
   Game: ResolverTypeWrapper<Game>;
+  GameSettings: ResolverTypeWrapper<GameSettings>;
+  GameSettingsInput: GameSettingsInput;
   ID: ResolverTypeWrapper<Scalars["ID"]>;
   Int: ResolverTypeWrapper<Scalars["Int"]>;
   Mission: ResolverTypeWrapper<Mission>;
@@ -304,6 +331,8 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   Scoreboard: ResolverTypeWrapper<Scoreboard>;
   ScoreboardPaginationInput: ScoreboardPaginationInput;
+  Settings: ResolverTypeWrapper<Settings>;
+  SettingsInput: SettingsInput;
   String: ResolverTypeWrapper<Scalars["String"]>;
   TokenResponse: ResolverTypeWrapper<TokenResponse>;
   User: ResolverTypeWrapper<User>;
@@ -317,6 +346,8 @@ export type ResolversParentTypes = {
   Date: Scalars["Date"];
   Decimal: Scalars["Decimal"];
   Game: Game;
+  GameSettings: GameSettings;
+  GameSettingsInput: GameSettingsInput;
   ID: Scalars["ID"];
   Int: Scalars["Int"];
   Mission: Mission;
@@ -325,6 +356,8 @@ export type ResolversParentTypes = {
   Query: {};
   Scoreboard: Scoreboard;
   ScoreboardPaginationInput: ScoreboardPaginationInput;
+  Settings: Settings;
+  SettingsInput: SettingsInput;
   String: Scalars["String"];
   TokenResponse: TokenResponse;
   User: User;
@@ -373,6 +406,14 @@ export type GameResolvers<
   mission?: Resolver<Maybe<ResolversTypes["Mission"]>, ParentType, ContextType>;
   score?: Resolver<Maybe<ResolversTypes["Decimal"]>, ParentType, ContextType>;
   startedAt?: Resolver<ResolversTypes["Date"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GameSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["GameSettings"] = ResolversParentTypes["GameSettings"]
+> = {
+  showTutorial?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -443,6 +484,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationUnselectBugArgs, "bugId" | "gameId">
   >;
+  updateSettings?: Resolver<
+    ResolversTypes["Settings"],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateSettingsArgs, "settings">
+  >;
 };
 
 export type QueryResolvers<
@@ -512,6 +559,19 @@ export type ScoreboardResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type SettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["Settings"] = ResolversParentTypes["Settings"]
+> = {
+  gameSettings?: Resolver<
+    Maybe<ResolversTypes["GameSettings"]>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type TokenResponseResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["TokenResponse"] = ResolversParentTypes["TokenResponse"]
@@ -540,6 +600,11 @@ export type UserResolvers<
     ContextType,
     Partial<UserScoreboardsArgs>
   >;
+  settings?: Resolver<
+    Maybe<ResolversTypes["Settings"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -549,11 +614,13 @@ export type Resolvers<ContextType = any> = {
   Date?: GraphQLScalarType;
   Decimal?: GraphQLScalarType;
   Game?: GameResolvers<ContextType>;
+  GameSettings?: GameSettingsResolvers<ContextType>;
   Mission?: MissionResolvers<ContextType>;
   MissionSourceCode?: MissionSourceCodeResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Scoreboard?: ScoreboardResolvers<ContextType>;
+  Settings?: SettingsResolvers<ContextType>;
   TokenResponse?: TokenResponseResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -6,6 +6,7 @@ import { gameResolver, gameSchema } from "./game";
 import { dateResolver, dateSchema } from "./date";
 import { decimalResolver, decimalSchema } from "./decimal";
 import { scoreboardResolver, scoreboardSchema } from "./scoreboard";
+import { settingsResolver, settingsSchema } from "./settings";
 
 const baseSchema = `#graphql
   type Query {
@@ -40,6 +41,7 @@ export const typeDefs = [
   missionSchema,
   gameSchema,
   scoreboardSchema,
+  settingsSchema,
 ];
 export const resolvers = [
   baseResolver,
@@ -49,4 +51,5 @@ export const resolvers = [
   missionResolver,
   gameResolver,
   scoreboardResolver,
+  settingsResolver,
 ];

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -1,0 +1,78 @@
+import { Context } from "@context";
+import { GraphQLNotFoundError, GraphQLUnauthorizedError } from "@error";
+import { Resolvers } from "@gql";
+
+export const settingsSchema = `#graphql
+  type GameSettings {
+    showTutorial: Boolean!
+  }
+
+  type Settings {
+    id: ID!
+    gameSettings: GameSettings
+  }
+
+  input GameSettingsInput {
+    showTutorial: Boolean!
+  }
+
+  input SettingsInput {
+    gameSettings: GameSettingsInput
+  }
+
+  extend type Mutation {
+    updateSettings(settings: SettingsInput!): Settings!
+  }
+`;
+
+export const settingsResolver: Resolvers<Context> = {
+  Settings: {
+    gameSettings: async (settings, _, { prisma, user }) => {
+      if (!user) throw new GraphQLUnauthorizedError();
+
+      const gameSettings = await prisma.settings
+        .findUnique({
+          where: {
+            id: settings.id,
+          },
+        })
+        .gameSettings();
+
+      return gameSettings;
+    },
+  },
+  Mutation: {
+    updateSettings: async (_, { settings }, { prisma, user }) => {
+      if (!user) throw new GraphQLUnauthorizedError();
+
+      const updatedSettings = await prisma.settings.upsert({
+        where: {
+          id: user.id,
+        },
+        update: {
+          gameSettings: settings.gameSettings
+            ? {
+                upsert: {
+                  create: settings.gameSettings,
+                  update: settings.gameSettings,
+                },
+              }
+            : undefined,
+        },
+        create: {
+          id: user.id,
+          gameSettings: settings.gameSettings
+            ? {
+                create: settings.gameSettings,
+              }
+            : undefined,
+        },
+        include: {
+          gameSettings: true,
+        },
+      });
+
+      return updatedSettings;
+    },
+  },
+};


### PR DESCRIPTION
## Tickets

https://x-team-internal.atlassian.net/browse/VG-24

## Description

Added user settings to the schema to handle if the user should see the tutorial.

### Migration

Added two tables.
`Settings` is a one-to-one relationship between the user and the different types of settings _(initially, `GameSettings` is the only one)_.
`GameSettings` will hold the game-specific settings.

### Resolvers

Added a field resolver for settings in the user type.

Added mutation to update settings. 

## Demo

[<img width="1265" alt="image" src="https://user-images.githubusercontent.com/31192466/210889034-498ab027-93e0-4f04-8668-6d627dcc9051.png">](https://vimeo.com/786732029/0c984b6e1c)

